### PR TITLE
README: Breakdown lines of the license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,7 @@ Currently we decided not to push any docker image with previous versions than th
 ## License
 
 The MIT License (MIT)
-Copyright (c) 2018 cycloid.io
+
+Copyright (c) 2018 [cycloid.io](https://cycloid.io)
+
 Read the LICENSE file for more information.


### PR DESCRIPTION
Breakdown the lines of the _License_ section of the _README_ as they were conceived to be separated lines, but unappropriated _markdown_ format was used.