### PR TITLE
Improve the docker build image parametrizing the MailSlurper version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,12 @@ LABEL "io.cycloid"="Cycloid" \
       "description"="A docker image of MailSlurper SMTP server" \
       "reference"="https://github.com/mailslurper/mailslurper"
 
+ARG MSP_VER
 WORKDIR /go/src
 RUN mkdir -p github.com/mailslurper/mailslurper \
     && cd github.com/mailslurper/mailslurper \
     && git clone https://github.com/mailslurper/mailslurper.git . \
-    && git checkout 1.14.1 \
+    && git checkout $MSP_VER \
     && go get github.com/mjibson/esc \
     && cd cmd/mailslurper \
     && go get \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help: ## Show this help
 
 .PHONY: build
 build: ## Build the docker image
-	@docker build -t cycloid/mailslurper:$(VERSION) .
+	@docker build --build-arg MSP_VER=$(VERSION) -t cycloid/mailslurper:$(VERSION) .
 
 
 .PHONY: push


### PR DESCRIPTION
Improve the build of the docker image parametrizing the MailSlurper version in the Dockerfile and passing the version which is defined in the Makefile.